### PR TITLE
Don't set innerHTML in demo unless it is empty

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -49,8 +49,9 @@
     // Sanity-check the component loaded...
     setTimeout(function () {
       var content = document.querySelector("#content");
-      content.innerHTML = content.innerHTML ||
-        "If you can see this, something is broken (or JS is not enabled)!";
+      if (!content.innerHTML) {
+        content.innerHTML = "If you can see this, something is broken (or JS is not enabled)!";
+      }
     }, 500);
   </script>
 </body>


### PR DESCRIPTION
Doing `content.innerHTML = content.innerHTML` can break some things in React, at least in Chrome (for example, event listeners). It might break other things, so might as well just avoid doing it.
